### PR TITLE
chore(KFLUXVNGD-282): rename rpms-signature-scan-pull-request pipeline

### DIFF
--- a/.tekton/rpms-signature-scan-tests-pull-request.yaml
+++ b/.tekton/rpms-signature-scan-tests-pull-request.yaml
@@ -14,7 +14,7 @@ metadata:
     appstudio.openshift.io/application: tekton-tools
     appstudio.openshift.io/component: tekton-tools
     pipelines.appstudio.openshift.io/type: build
-  name: rpms-signature-scan-pull-request
+  name: rpms-signature-scan-tests-pull-request
   namespace: konflux-vanguard-tenant
 spec:
   pipelineSpec:


### PR DESCRIPTION
Rename rpms-signature-scan-pull-request pipeline to rpms-signature-scan-tests-pull-request

We are renaming it because when we onboard the rpms-signature-scan task to konflux, a pipeline with the same name is created.