### PR TITLE
chore: remove on-cel-expression

### DIFF
--- a/.tekton/rpms-signature-scan-pull-request.yaml
+++ b/.tekton/rpms-signature-scan-pull-request.yaml
@@ -8,12 +8,7 @@ metadata:
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/cancel-in-progress: "true"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
-    pipelinesascode.tekton.dev/on-cel-expression: |
-      event == "pull_request"
-      && target_branch == "main"
-      && (
-        "tasks/rpms-signature-scan/0.2/***".pathChanged() || ".tekton/rpms-signature-scan-pull-request.yaml".pathChanged()
-      )
+    pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch == "main"
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: tekton-tools


### PR DESCRIPTION
Remove on-cel-expression as a workaround to allow branch protection
Once https://issues.redhat.com/browse/KONFLUX-7897 will be in place we will be able to revert this workaround