### PR TITLE
Limit push builds to task/ directory changes

### DIFF
--- a/.tekton/rpms-signature-scan-v02-push.yaml
+++ b/.tekton/rpms-signature-scan-v02-push.yaml
@@ -7,12 +7,8 @@ metadata:
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/cancel-in-progress: "false"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
-    pipelinesascode.tekton.dev/on-cel-expression: |
-      event == "push"
-      && target_branch == "main"
-      && (
-        "tasks/rpms-signature-scan/0.2/***".pathChanged() || ".tekton/rpms-signature-scan-v02-push.yaml".pathChanged()
-      )
+    pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch
+      == "main" && "tasks/rpms-signature-scan/0.2/***".pathChanged()
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: tekton-tools


### PR DESCRIPTION
The current configuration is generating new bundles whenever the build pipeline itself is changed, such as with new konflux reference updates.

The ReleasePlan for these tasks is an autoreleasing one, so this is constantly updating the bundle on quay without any changes to the actual yaml file on the tekton bundle.

Limit the push pipeline runs to changes on the task files to avoid unnecessary noise republishing the same task over and over again