### PR TITLE
Pin GitHub Actions to commit SHAs

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -11,7 +11,7 @@ jobs:
   validate-agents-md:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7
       - name: Validate AGENTS.md line count
         run: |
           MAX_LINES=300


### PR DESCRIPTION
## Summary
- Pin GitHub Actions in workflows to full 40-character commit SHAs with inline version comments so Renovate can keep updating them.
- Leave org reusable `fullsend` workflow refs on `@main` unchanged where present.

## Test plan
- [ ] Workflows that use the pinned actions still pass CI
- [ ] YAML lint (if present) is clean for comment spacing before `#`

Made with [Cursor](https://cursor.com)