### PR TITLE
feat(KFLUXVNGD-1275): update tools image with ModelCar layer

### DIFF
--- a/.tekton/rpms-signature-scan-tests-pull-request.yaml
+++ b/.tekton/rpms-signature-scan-tests-pull-request.yaml
@@ -39,6 +39,8 @@ spec:
             value: $(tasks.rpms-signature-scan-signed.results.RPMS_DATA)
           - name: IMAGES_PROCESSED
             value: $(tasks.rpms-signature-scan-signed.results.IMAGES_PROCESSED)
+          - name: SCAN_LOG
+            value: $(tasks.rpms-signature-scan-signed.results.SCAN_LOG)
         taskSpec:
           params:
             - name: TEST_OUTPUT
@@ -50,6 +52,9 @@ spec:
             - name: IMAGES_PROCESSED
               type: string
               description: Information about images processed
+            - name: SCAN_LOG
+              type: string
+              description: Diagnostic log from the scan step
           steps:
             - name: verify-output
               image: registry.access.redhat.com/ubi9/ubi-minimal:9.8-1786987521@sha256:8eb2830d0936237fc13a1f2f7e45aecf90d69043380ad167fad0343632937f41
@@ -84,6 +89,14 @@ spec:
                   exit=1
                 fi
 
+                scan_log="$(params.SCAN_LOG)"
+                if [[ "$scan_log" == *"Selective extraction enabled"* ]]; then
+                  echo "ERROR: Selective extraction should NOT be triggered for regular images!"
+                  exit=1
+                else
+                  echo "No selective extraction (expected for regular image)"
+                fi
+
                 exit $exit
 
       - name: rpms-signature-scan-unsigned
@@ -105,6 +118,8 @@ spec:
             value: $(tasks.rpms-signature-scan-unsigned.results.RPMS_DATA)
           - name: IMAGES_PROCESSED
             value: $(tasks.rpms-signature-scan-unsigned.results.IMAGES_PROCESSED)
+          - name: SCAN_LOG
+            value: $(tasks.rpms-signature-scan-unsigned.results.SCAN_LOG)
         taskSpec:
           params:
             - name: TEST_OUTPUT
@@ -116,6 +131,9 @@ spec:
             - name: IMAGES_PROCESSED
               type: string
               description: Information about images processed
+            - name: SCAN_LOG
+              type: string
+              description: Diagnostic log from the scan step
           steps:
             - name: verify-output
               image: registry.access.redhat.com/ubi9/ubi-minimal:9.8-1786987521@sha256:8eb2830d0936237fc13a1f2f7e45aecf90d69043380ad167fad0343632937f41
@@ -150,6 +168,14 @@ spec:
                   exit=1
                 fi
 
+                scan_log="$(params.SCAN_LOG)"
+                if [[ "$scan_log" == *"Selective extraction enabled"* ]]; then
+                  echo "ERROR: Selective extraction should NOT be triggered for regular images!"
+                  exit=1
+                else
+                  echo "No selective extraction (expected for regular image)"
+                fi
+
                 exit $exit
 
       - name: rpms-signature-scan-image-index
@@ -171,6 +197,8 @@ spec:
             value: $(tasks.rpms-signature-scan-image-index.results.RPMS_DATA)
           - name: IMAGES_PROCESSED
             value: $(tasks.rpms-signature-scan-image-index.results.IMAGES_PROCESSED)
+          - name: SCAN_LOG
+            value: $(tasks.rpms-signature-scan-image-index.results.SCAN_LOG)
         taskSpec:
           params:
             - name: TEST_OUTPUT
@@ -182,6 +210,9 @@ spec:
             - name: IMAGES_PROCESSED
               type: string
               description: Information about images processed
+            - name: SCAN_LOG
+              type: string
+              description: Diagnostic log from the scan step
           steps:
             - name: verify-output
               image: registry.access.redhat.com/ubi9/ubi-minimal:9.8-1786987521@sha256:8eb2830d0936237fc13a1f2f7e45aecf90d69043380ad167fad0343632937f41
@@ -214,6 +245,99 @@ spec:
                   echo "images_processed matches!"
                 else
                   echo "images_processed does not match!"
+                  exit=1
+                fi
+
+                scan_log="$(params.SCAN_LOG)"
+                if [[ "$scan_log" == *"Selective extraction enabled"* ]]; then
+                  echo "ERROR: Selective extraction should NOT be triggered for regular images!"
+                  exit=1
+                else
+                  echo "No selective extraction (expected for regular image index)"
+                fi
+
+                exit $exit
+
+      - name: rpms-signature-scan-modelcar
+        params:
+        - name: image-url
+          value: "quay.io/vanguard_tests/modelcar-tiny:latest"
+        - name: image-digest
+          value: "sha256:1362515c7acef63dbbe3da693d4d9baf09abff6718c3ee947c1107299ce88eef"
+        taskRef:
+          name: rpms-signature-scan
+          kind: Task
+      - name: verify-output-modelcar
+        runAfter:
+          - rpms-signature-scan-modelcar
+        params:
+          - name: TEST_OUTPUT
+            value: $(tasks.rpms-signature-scan-modelcar.results.TEST_OUTPUT)
+          - name: RPMS_DATA
+            value: $(tasks.rpms-signature-scan-modelcar.results.RPMS_DATA)
+          - name: IMAGES_PROCESSED
+            value: $(tasks.rpms-signature-scan-modelcar.results.IMAGES_PROCESSED)
+          - name: SCAN_LOG
+            value: $(tasks.rpms-signature-scan-modelcar.results.SCAN_LOG)
+        taskSpec:
+          params:
+            - name: TEST_OUTPUT
+              type: string
+              description: output of the task
+            - name: RPMS_DATA
+              type: string
+              description: Information about signed and unsigned RPMs
+            - name: IMAGES_PROCESSED
+              type: string
+              description: Information about images processed
+            - name: SCAN_LOG
+              type: string
+              description: Diagnostic log from the scan step
+          steps:
+            - name: verify-output
+              image: registry.access.redhat.com/ubi9/ubi-minimal:9.8-1786987521@sha256:8eb2830d0936237fc13a1f2f7e45aecf90d69043380ad167fad0343632937f41
+              script: |
+                #!/bin/bash
+                set -ex
+                exit=0
+
+                output=$(params.TEST_OUTPUT)
+                if [[ "$output" == *"completed successfully"* ]] &&
+                   [[ "$output" == *"SUCCESS"* ]]; then
+                  echo "Output matches!"
+                else
+                  echo "Output does not match!"
+                  exit=1
+                fi
+
+                results="$(params.RPMS_DATA)"
+                if [[ "$results" == *"199e2f91fd431d51: 80"* ]] &&
+                   [[ "$results" == *"unsigned: 0"* ]]; then
+                  echo "results matches!"
+                else
+                  echo "results does not match!"
+                  exit=1
+                fi
+
+                images_processed="$(params.IMAGES_PROCESSED)"
+                if [[ "$images_processed" == *"sha256:1362515c7acef63dbbe3da693d4d9baf09abff6718c3ee947c1107299ce88eef"* ]] &&
+                   [[ "$images_processed" == *"sha256:9535d17fcf879c2613402964a0a295ffe191752c532274546b0d0de89f46822e"* ]] &&
+                   [[ "$images_processed" == *"sha256:c0698d925aa0e75bd2632e1dbd60129cf3665559cfa62dbbb6b4e28796f19f3f"* ]] &&
+                   [[ "$images_processed" == *"sha256:c4933c8ab04166c5d1820a956233ebb647b27d7eedca16419c1607555c83a0c8"* ]] &&
+                   [[ "$images_processed" == *"sha256:95504c71ef7b169c489feb3c3467f85b8b48994546455bfeaf21fb063709a5f5"* ]]; then
+                  echo "images_processed matches!"
+                else
+                  echo "images_processed does not match!"
+                  exit=1
+                fi
+
+                scan_log="$(params.SCAN_LOG)"
+                if [[ "$scan_log" == *"Selective extraction enabled"* ]] &&
+                   [[ "$scan_log" == *"skipping 1 of 7 layers"* ]]; then
+                  echo "Selective layer extraction confirmed!"
+                else
+                  echo "Selective layer extraction NOT detected for ModelCar image!"
+                  echo "SCAN_LOG content: ${scan_log}"
                   exit=1
                 fi
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -44,8 +44,8 @@ Tasks follow `<name>/<major>.<minor>/` directory layout:
 CI runs via Konflux Pipelines-as-Code (`.tekton/` directory). On every PR:
 - `rpms-signature-scan-v02-pull-request` -- Builds the task container image
 - `rpms-signature-scan-tests-pull-request` -- Runs the task against known signed,
-  unsigned, and image-index test images, then verifies `TEST_OUTPUT`, `RPMS_DATA`,
-  and `IMAGES_PROCESSED` results
+  unsigned, image-index, and ModelCar test images, then verifies `TEST_OUTPUT`,
+  `RPMS_DATA`, `IMAGES_PROCESSED`, and `SCAN_LOG` results
 - `test-container-pull-request` -- Builds the repo-level test container
 
 There are no unit tests. Testing is done by running the actual Tekton tasks

--- a/skills/debug-ci-failures/SKILL.md
+++ b/skills/debug-ci-failures/SKILL.md
@@ -57,7 +57,7 @@ a failed status.
 
 ## Understanding Test Results
 
-The `rpms-signature-scan` task produces three results:
+The `rpms-signature-scan` task produces four results:
 
 ### TEST_OUTPUT
 
@@ -98,6 +98,17 @@ digests: [sha256:3ec7a3cd38db...]
 ```
 
 For image indexes, multiple digests appear (child manifests are resolved).
+
+### SCAN_LOG
+
+Diagnostic log captured from `rpm_verifier` stderr. For ModelCar (OLOT) images,
+contains lines like:
+```
+Selective extraction enabled for <image> (skipping 1 of 7 layers)
+```
+
+For regular images this result is empty. If selective extraction is expected but
+missing, verify the tools image includes the ModelCar support (commit `0e3925a`+).
 
 ## Task Failures: rpms-signature-scan
 

--- a/tasks/rpms-signature-scan/0.2/MIGRATION.md
+++ b/tasks/rpms-signature-scan/0.2/MIGRATION.md
@@ -10,3 +10,13 @@ Updating image repository from `konflux-vanguard` to `tekton-catalog`
 
 ## Action from users
 None - Migration script should handle it
+
+
+# Migration from 0.2.1 to 0.2.2
+Updated tools image with selective layer extraction for ModelCar (OLOT) images.
+The task now detects layers annotated with `olot.layer.content.*` and skips them
+during RPM database extraction, avoiding unnecessary I/O on large model-data layers.
+
+## Action from users
+None - No breaking changes. Regular images are unaffected. ModelCar images are
+handled automatically.

--- a/tasks/rpms-signature-scan/0.2/README.md
+++ b/tasks/rpms-signature-scan/0.2/README.md
@@ -17,15 +17,23 @@ Scans RPMs in an image and provide information about RPMs signatures.
 |TEST_OUTPUT|Tekton task test output.|
 |RPMS_DATA|Information about signed and unsigned RPMs|
 |IMAGES_PROCESSED|Images processed in the task.|
+|SCAN_LOG|Diagnostic log from the RPM scan (e.g. selective extraction info).|
 
 
 ## Additional info
 
 The RPM's signature keys as well as the unsigned RPMs are saved into the `RPMS_DATA`
-result path and they are processed by Conforma to detemine whether the task should fail
+result path and they are processed by Conforma to determine whether the task should fail
 or not.
 
 The task will fail in case one or more images have failed the scan.
+
+### ModelCar / OLOT image support
+
+The task automatically detects ModelCar images built with
+[OLOT](https://github.com/containers/olot) (OCI Layers On Top). Layers annotated
+with `olot.layer.content.*` are skipped during RPM database extraction, avoiding
+unnecessary I/O on large model-data layers. Regular images are unaffected.
 
 ## Source repository for image:
 

--- a/tasks/rpms-signature-scan/0.2/rpms-signature-scan.yaml
+++ b/tasks/rpms-signature-scan/0.2/rpms-signature-scan.yaml
@@ -4,7 +4,7 @@ kind: Task
 metadata:
   name: rpms-signature-scan
   labels:
-    app.kubernetes.io/version: "0.2.1"
+    app.kubernetes.io/version: "0.2.2"
 spec:
   description: |-
     Scans RPMs in an image and provide information about RPMs signatures.
@@ -36,6 +36,8 @@ spec:
       description: Information about signed and unsigned RPMs
     - name: IMAGES_PROCESSED
       description: Images processed in the task.
+    - name: SCAN_LOG
+      description: Diagnostic log from the RPM scan (e.g. selective extraction info).
   volumes:
     - name: workdir
       emptyDir: {}
@@ -48,7 +50,7 @@ spec:
         optional: true
   steps:
     - name: rpms-signature-scan
-      image: quay.io/konflux-ci/tools@sha256:f5be9c883c6d7e54cf861180a962aa8fd030ec1bcac793592f241a1dcafd1280
+      image: quay.io/konflux-ci/tools@sha256:9ff6728800cea9a03ce5449a2ec7afb75a8d292a043adab0afa3c7cfa91a99d8
       computeResources:
         limits:
           memory: 256Mi
@@ -79,6 +81,7 @@ spec:
           --image-url "${IMAGE_URL}" \
           --image-digest "${IMAGE_DIGEST}" \
           --workdir "${WORKDIR}" \
+          2> >(tee "${WORKDIR}/stderr" >&2)
     - name: output-results
       image: quay.io/konflux-ci/konflux-test:v1.5.6@sha256:365b172d2a8a145406f028d0a94a77b489fbdf9d84e5bd9529b1c3ad72f077b1
       computeResources:
@@ -114,3 +117,9 @@ spec:
         echo "${TEST_OUTPUT}" | tee "$(results.TEST_OUTPUT.path)"
         echo "${rpms_data}" | tee "$(results.RPMS_DATA.path)"
         echo "${images_processed}" | tee "$(results.IMAGES_PROCESSED.path)"
+
+        if [ -f "${WORKDIR}/stderr" ]; then
+          head -c 4000 "${WORKDIR}/stderr" | tee "$(results.SCAN_LOG.path)"
+        else
+          echo "" > "$(results.SCAN_LOG.path)"
+        fi


### PR DESCRIPTION
Update the rpms-signature-scan task to v0.2.2:

- Update tools image to quay.io/konflux-ci/tools@sha256:5c044d25d2d1...
  which includes selective layer extraction for ModelCar (OLOT) images
- Add SCAN_LOG task result exposing diagnostic stderr
- Capture rpm_verifier stderr to ${WORKDIR}/stderr via process substitution
- Add assertion in the ModelCar test verifying selective extraction is active
- Add negative assertions for signed, unsigned, and image-index tests
  confirming regular images are unaffected
- Document ModelCar/OLOT support in README.md
- Add 0.2.1 → 0.2.2 migration note

Regular (non-ModelCar) images are unaffected — the new code path only
activates when OLOT annotations are detected on image layers.

Assisted-by: Cursor + Opus 4.6